### PR TITLE
Use shared vietnormalizer CSV data

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ singapore,xin-ga-po
 server,xơ-vơ
 ```
 
+For more details about the built-in CSV dictionaries and their structure, see `vietnormalizer/data/README.md`.
+
 ## Advanced Usage
 
 ### Using the Processor Directly

--- a/predict.py
+++ b/predict.py
@@ -424,10 +424,11 @@ class Predictor(BasePredictor):
             self.replacements = {}
     
     def _load_acronyms(self) -> Dict[str, str]:
-        """Load acronym mappings from CSV."""
+        """Load acronym mappings from the shared vietnormalizer data CSV."""
         acronym_map = {}
-        acronyms_path = Path("public/acronyms.csv")
-        
+        data_dir = Path(__file__).resolve().parent / "vietnormalizer" / "data"
+        acronyms_path = data_dir / "acronyms.csv"
+
         if acronyms_path.exists():
             with open(acronyms_path, "r", encoding="utf-8") as f:
                 reader = csv.DictReader(f)
@@ -436,24 +437,26 @@ class Predictor(BasePredictor):
                     transliteration = row.get("transliteration", "").strip()
                     if acronym and transliteration:
                         acronym_map[acronym] = transliteration
-        
+
         # Sort by length (longest first) for proper matching priority
         return dict(sorted(acronym_map.items(), key=lambda x: len(x[0]), reverse=True))
     
     def _load_non_vietnamese_words(self) -> Dict[str, str]:
-        """Load non-Vietnamese word mappings from CSV."""
+        """Load non-Vietnamese word mappings from the shared vietnormalizer data CSV."""
         word_map = {}
-        words_path = Path("public/non-vietnamese-words.csv")
-        
+        data_dir = Path(__file__).resolve().parent / "vietnormalizer" / "data"
+        words_path = data_dir / "non-vietnamese-words.csv"
+
         if words_path.exists():
             with open(words_path, "r", encoding="utf-8") as f:
                 reader = csv.DictReader(f)
                 for row in reader:
-                    word = row.get("word", "").strip().lower()
-                    pronunciation = row.get("vietnamese_pronunciation", "").strip()
+                    # Support both the public/ and package CSV header formats
+                    word = (row.get("word", "") or row.get("original", "")).strip().lower()
+                    pronunciation = (row.get("vietnamese_pronunciation", "") or row.get("transliteration", "")).strip()
                     if word and pronunciation:
                         word_map[word] = pronunciation
-        
+
         # Sort by length (longest first) for proper matching priority
         return dict(sorted(word_map.items(), key=lambda x: len(x[0]), reverse=True))
     

--- a/vietnormalizer/data/README.md
+++ b/vietnormalizer/data/README.md
@@ -1,0 +1,14 @@
+## vietnormalizer CSV data
+
+This directory contains the **single source of truth** CSV dictionaries used by `vietnormalizer` and related tools.
+
+- **`acronyms.csv`**  
+  - Columns: `acronym`, `transliteration`  
+  - Maps common acronyms (for example `UBND`, `NASA`, `AI`) to how they should be read in Vietnamese.
+
+- **`non-vietnamese-words.csv`**  
+  - Columns: `original`, `transliteration`  
+  - Large dictionary of non‑Vietnamese words and their intended Vietnamese pronunciations (for example `container → công-tê-nơ`).
+
+All code in this repository that needs these dictionaries should read from the files in this directory (or a copy derived from them), not from any other CSV source.
+


### PR DESCRIPTION
Read acronym and non‑Vietnamese word CSVs from vietnormalizer/data instead of public/, and accept both legacy and package CSV header names for compatibility. Add vietnormalizer/data/README.md documenting the CSV formats, and link that README from the top-level README to explain the single source of truth for these dictionaries.

Fixed #12